### PR TITLE
Add r2 sdb include directory to meson.build

### DIFF
--- a/p/meson.build
+++ b/p/meson.build
@@ -25,6 +25,7 @@ deps += cc.find_library('m', required: false)
 
 if r2_incdir != ''
   incs += r2_incdir
+  incs += r2_incdir + '/sdb'
 endif
 
 incs += 'duktape'


### PR DESCRIPTION
<!--- Filling this template is mandatory -->

**Detailed description**

R2 currently expect libr/sdb folder to be in include path.

The makefile build currently avoids this problem by using pkgconfig. Meson could use that as well but, pkconfig on Windows is somewhat problematic. Doesn't seem like there is a popular and maintained binary distribution of pkgconfig for windows. Cygwin and msys don't count it needs to work outside those environments. If anyone knows let me know.



**Test plan**

Compile on Windows using meson against latest r2. 

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
